### PR TITLE
Adds examples for `lambda` and `sfn` CRDs

### DIFF
--- a/resources/lambda/v1alpha1/alias.yaml
+++ b/resources/lambda/v1alpha1/alias.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: lambda.services.k8s.aws/v1alpha1
+kind: Alias
+metadata:
+  name: $ALIAS_NAME
+  annotations:
+    services.k8s.aws/region: $AWS_REGION
+spec:
+  name: $ALIAS_NAME
+  functionName: $FUNCTION_NAME
+  functionVersion: $FUNCTION_VERSION
+  description: $FUNCTION_DESCRIPTION

--- a/resources/lambda/v1alpha1/codesigningconfig.yaml
+++ b/resources/lambda/v1alpha1/codesigningconfig.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: lambda.services.k8s.aws/v1alpha1
+kind: CodeSigningConfig
+metadata:
+  name: $CODE_SIGNING_CONFIG_NAME
+spec:
+  allowedPublishers:
+    signingProfileVersionARNs:
+    - $SIGNING_PROFILE_VERSION_ARN
+  description: $CODE_SIGNING_CONFIG_DESCRIPTION

--- a/resources/lambda/v1alpha1/eventsourcemapping-with-dynamodb-table.yaml
+++ b/resources/lambda/v1alpha1/eventsourcemapping-with-dynamodb-table.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: lambda.services.k8s.aws/v1alpha1
+kind: EventSourceMapping
+metadata:
+  name: $EVENT_SOURCE_MAPPING_NAME
+  annotations:
+    services.k8s.aws/region: $AWS_REGION
+spec:
+  functionName: $FUNCTION_NAME
+  eventSourceARN: $EVENT_SOURCE_ARN
+  startingPosition: $STARTING_POSITION
+  maximumRetryAttempts: $MAXIMUM_RETRY_ATTEMPTS
+  batchSize: $BATCH_SIZE
+  enabled: false

--- a/resources/lambda/v1alpha1/eventsourcemapping-with-sqs.yaml
+++ b/resources/lambda/v1alpha1/eventsourcemapping-with-sqs.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: lambda.services.k8s.aws/v1alpha1
+kind: EventSourceMapping
+metadata:
+  name: $EVENT_SOURCE_MAPPING_NAME
+  annotations:
+    services.k8s.aws/region: $AWS_REGION
+spec:
+  functionName: $FUNCTION_NAME
+  eventSourceARN: $EVENT_SOURCE_ARN
+  batchSize: $BATCH_SIZE
+  maximumBatchingWindowInSeconds: $MAXIMUM_BATCHING_WINDOW_IN_SECONDS
+  enabled: false

--- a/resources/lambda/v1alpha1/function-with-s3.yaml
+++ b/resources/lambda/v1alpha1/function-with-s3.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: lambda.services.k8s.aws/v1alpha1
+kind: Function
+metadata:
+  name: $FUNCTION_NAME
+  annotations:
+    services.k8s.aws/region: $AWS_REGION
+spec:
+  name: $FUNCTION_NAME
+  code:
+    s3Bucket: $BUCKET_NAME
+    s3Key: $LAMBDA_FILE_NAME
+  role: $LAMBDA_ROLE
+  runtime: $FUNCTION_RUNTIME
+  handler: $FUNCTION_HANDLER
+  description: $DESCRIPTION
+  reservedConcurrentExecutions: $RESERVED_CONCURRENT_EXECUTIONS
+  codeSigningConfigARN: "$CODE_SIGNING_CONFIG_ARN"

--- a/resources/lambda/v1alpha1/functions-with-oci-image.yaml
+++ b/resources/lambda/v1alpha1/functions-with-oci-image.yaml
@@ -1,0 +1,13 @@
+apiVersion: lambda.services.k8s.aws/v1alpha1
+kind: Function
+metadata:
+  name: $FUNCTION_NAME
+  annotations:
+    services.k8s.aws/region: $AWS_REGION
+spec:
+  name: $FUNCTION_NAME
+  packageType: Image
+  code:
+    imageURI: $IMAGE_URL
+  role: $LAMBDA_ROLE
+  description: $DESCRIPTION

--- a/resources/lambda/v1alpha1/functionurlconfig.yaml
+++ b/resources/lambda/v1alpha1/functionurlconfig.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: lambda.services.k8s.aws/v1alpha1
+kind: FunctionURLConfig
+metadata:
+  name: $FUNCTION_URL_CONFIG_NAME
+  annotations:
+    services.k8s.aws/region: $AWS_REGION
+spec:
+  functionName: $FUNCTION_NAME
+  authType: $AUTH_TYPE

--- a/resources/sfn/v1alpha1/activity.yaml
+++ b/resources/sfn/v1alpha1/activity.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: sfn.services.k8s.aws/v1alpha1
+kind: Activity
+metadata:
+  name: $ACTIVITY_NAME
+spec:
+  name: $ACTIVITY_NAME

--- a/resources/sfn/v1alpha1/statemachine.yaml
+++ b/resources/sfn/v1alpha1/statemachine.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: sfn.services.k8s.aws/v1alpha1
+kind: StateMachine
+metadata:
+  name: $STATE_MACHINE_NAME
+spec:
+  name: $STATE_MACHINE_NAME
+  roleARN: $ROLE_ARN
+  tracingConfiguration:
+    enabled: true
+  definition: | 
+    {
+      "StartAt": "HelloWorld",
+      "States": {
+        "HelloWorld": {
+          "Type": "Pass",
+          "Result": "Hello World!",
+          "End": true
+        }
+      }
+    }


### PR DESCRIPTION
This patch adds 8 new examples for various resources for lambda and sfn
custom resources.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
